### PR TITLE
Dev Experience: add webpack build script to package to json

### DIFF
--- a/extention/package.json
+++ b/extention/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "popup.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "webpack --config webpack.config.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
This PR is intended to add a script in `package.json` to allow for more convenient and more fault tolerant front-end development. 

## How it worked before:
1. Make your changes
2. Run `npx webpack --config webpack.config.js`
3. Go to `chrome://extensions/`
4. Select `Load Unpacked`
5. Go to the extension directory

I know that I will forget/misspell the command for step 2, so I've added it to the `package.json`. Here's how this works with the new change:

## How it works now:
1. Make your changes
2. Run `npm run build` // NEW
3. Go to `chrome://extensions/`
4. Select `Load Unpacked`
5. Go to the extension directory

Now you don't have to remember the command or misspell it anymore!

Also, as a pro tip, if you've already loaded in the extension you can just hit the refresh icon **after building your changes** and they will update in chrome!

![image](https://github.com/user-attachments/assets/a17f50e3-860d-4bca-8b6a-2cb04f4333e9)
^ see the refresh button next to the extension toggle