### PR TITLE
Lea 97 - Chat History Per Video & Fix Refresh Duplication Issue

### DIFF
--- a/extention/components/chatContainer.js
+++ b/extention/components/chatContainer.js
@@ -202,7 +202,9 @@ export function createChatContainer(parentElement) {
     }
   });
 
-// Restore chat history without duplication
+// Using setTimeout with 0ms delay to Stop execution until the DOM has fully rendered when refreshing the page.
+// This ensures that chat bubbles are only appended after the container is in place,
+// which prevents duplicate messages from being added when the page is refreshed.
 setTimeout(() => {
   const videoId = new URLSearchParams(new URL(window.location.href).search).get('v');
   const key = `chatHistory-${videoId}`;


### PR DESCRIPTION
Chat history is now scoped per YouTube videoId and stored in chrome.storage.local.

History persists across page reloads and tab changes.

Fixed duplication issue by clearing the chat area before re-rendering history. 

Modified the cahtContainer.js file within extension as that was responsible for chat storage. 

Here is a URL to a video I recoded showcasing its working. [https://drive.google.com/drive/folders/18RX3AufiDxb8DAgZl6hG3e3_tXg6uC2t?usp=sharing]