### PR TITLE
LEA-106 Fixing Frontend Caching on Process Fail

### DIFF
--- a/extention/js/content.js
+++ b/extention/js/content.js
@@ -59,21 +59,9 @@ function activateLearningMode() {
     }
 
     console.log('Learning Mode activated for User ID:', userId);
-
     const videoId = extractVideoID(window.location.href);
 
-    // Retrieve processed videos from localStorage
-    const processedVideos =
-      JSON.parse(localStorage.getItem('processedVideos')) || {};
-
-    if (!processedVideos[videoId]) {
-      sendVideoInfoToBackend(window.location.href, userId, userEmail);
-    } else {
-      setTimeout(() => hideModal(), 700);
-      console.log(
-        `Skipping processVideo: Video ${videoId} was already processed.`
-      );
-    }
+    sendVideoInfoToBackend(window.location.href, userId, userEmail);
     initializeLearningMode(userId);
   });
 }
@@ -180,6 +168,20 @@ export function hideModal() {
 }
 
 function sendVideoInfoToBackend(videoUrl, userId, userEmail) {
+  const videoId = extractVideoID(videoUrl);
+
+  // Retrieve processed videos from localStorage  const processedVideos =
+  const processedVideos =
+    JSON.parse(localStorage.getItem('processedVideos')) || {};
+  //Check if video was already processed + cached
+  if (processedVideos[videoId]) {
+    setTimeout(() => hideModal(), 700);
+    console.log(
+      `Skipping processVideo: Video ${videoId} was already processed.`
+    );
+    return;
+  }
+
   console.log(
     `Sending processVideo request for User: ${userId}, Email: ${userEmail}`
   );
@@ -219,13 +221,10 @@ function sendVideoInfoToBackend(videoUrl, userId, userEmail) {
       hideModal();
       addAIBubble('Video Processed! You can now ask questions.');
 
-      const videoId = extractVideoID(videoUrl);
-      const processedVideos = JSON.parse(localStorage.getItem('processedVideos')) || {};
-
       // Mark video as processed in local storage
       processedVideos[videoId] = true;
       localStorage.setItem('processedVideos', JSON.stringify(processedVideos));
-      console.log('✅ Video marked as processed in local storage')
+      console.log('✅ Video marked as processed in local storage');
       return fetch(`http://localhost:8080/verify-transcript/${videoId}`, {
         headers: {
           'User-ID': userId,

--- a/extention/js/content.js
+++ b/extention/js/content.js
@@ -68,10 +68,6 @@ function activateLearningMode() {
 
     if (!processedVideos[videoId]) {
       sendVideoInfoToBackend(window.location.href, userId, userEmail);
-
-      // Mark video as processed in local storage
-      processedVideos[videoId] = true;
-      localStorage.setItem('processedVideos', JSON.stringify(processedVideos));
     } else {
       setTimeout(() => hideModal(), 700);
       console.log(
@@ -224,6 +220,12 @@ function sendVideoInfoToBackend(videoUrl, userId, userEmail) {
       addAIBubble('Video Processed! You can now ask questions.');
 
       const videoId = extractVideoID(videoUrl);
+      const processedVideos = JSON.parse(localStorage.getItem('processedVideos')) || {};
+
+      // Mark video as processed in local storage
+      processedVideos[videoId] = true;
+      localStorage.setItem('processedVideos', JSON.stringify(processedVideos));
+      console.log('✅ Video marked as processed in local storage')
       return fetch(`http://localhost:8080/verify-transcript/${videoId}`, {
         headers: {
           'User-ID': userId,


### PR DESCRIPTION
## Problem

- Frontend would store videos as processed in local storage, even if processing failed

## Solution

- Moved caching to only occur after the `sendVideoInfoToBackend` gives us a 200 status. It will not store the video otherwise.
- Moved `localStorage.getItem('processedVideos')` to `sendVideoInfoToBackend`
- Moved checking local storage, and skipping if already in `processedVideos` to  `sendVideoInfoToBackend`

## Video
- I first attempt to process a video that's too long. Processing fails and `processedVideos` remains unchanged in local storage.
- Then I process a valid video. After success, I added a log for caching completion and the video ID is added to `processedVideos` in local storage.

https://github.com/user-attachments/assets/25b5b23c-299d-4a13-802c-3068d11ccb73


