### PR TITLE
LEA 107 Handle Video Processing Errors

### DIFF
--- a/extention/js/content.js
+++ b/extention/js/content.js
@@ -254,6 +254,13 @@ function sendVideoInfoToBackend(videoUrl, userId, userEmail) {
           updateModalMessage('⚠️ Server error. Please try again later.');
         });
     }
+
+    // Handle any other error status codes that weren't caught above
+    console.error(`🚨 Unexpected response status: ${response.status} - ${responseText}`);
+    updateModalMessage('⚠️ Server error. Please try again later.');
+  }).catch((error) => {
+    console.error('❌ Network or fetch error:', error);
+    updateModalMessage('⚠️ Network error. Please check your connection and try again.');
   });
 }
 


### PR DESCRIPTION
**Problem**
- Handle Video Processing Errors
- When video fails to process/fetch video info, it gives wrong error message

**Solution**
- Added logic to handle HTTP 500 errors explicitly.
- Updated the modal to display a clearer, more accurate error message when video info fails to load.

<img width="418" alt="Screenshot 2025-06-05 at 9 45 09 PM" src="https://github.com/user-attachments/assets/79039678-3f7a-453d-889c-4583f5557703" />