### PR TITLE
Feature/lea 119 long transcript truncation

### DIFF
--- a/backend/dockerfile
+++ b/backend/dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go binary
-FROM golang:1.21-alpine AS builder
+FROM golang:1.23-alpine AS builder
 
 WORKDIR /app
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,8 @@
 module Learning-Mode-AI
 
-go 1.21.5
+go 1.23
+
+toolchain go1.24.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
@@ -11,8 +13,10 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/redis/go-redis/v9 v9.7.1 // indirect
 	github.com/stripe/stripe-go/v81 v81.3.1 // indirect
+	github.com/tiktoken-go/tokenizer v0.6.2 // indirect
 )
 
 require (

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -3,6 +3,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
+github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
@@ -32,6 +34,8 @@ github.com/stripe/stripe-go/v81 v81.2.0 h1:AduJoFed6xif3uG7rXRa2LxY+AJiialVA1hXD
 github.com/stripe/stripe-go/v81 v81.2.0/go.mod h1:C/F4jlmnGNacvYtBp/LUHCvVUJEZffFQCobkzwY1WOo=
 github.com/stripe/stripe-go/v81 v81.3.1 h1:00ja19a2ya0yr+Fk5bBr9bhiSWpbEybfflPcVHzdKrE=
 github.com/stripe/stripe-go/v81 v81.3.1/go.mod h1:C/F4jlmnGNacvYtBp/LUHCvVUJEZffFQCobkzwY1WOo=
+github.com/tiktoken-go/tokenizer v0.6.2 h1:t0GN2DvcUZSFWT/62YOgoqb10y7gSXBGs0A+4VCQK+g=
+github.com/tiktoken-go/tokenizer v0.6.2/go.mod h1:6UCYI/DtOallbmL7sSy30p6YQv60qNyU/4aVigPOx6w=
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.28.0 h1:a9JDOJc5GMUJ0+UDqmLT86WiEy7iWyIhz8gz8E4e5hE=
 golang.org/x/net v0.28.0/go.mod h1:yqtgsTWOOnlGLG9GFRrK3++bGOUEkNBoHZc8MEDWPNg=

--- a/backend/pkg/handlers/videoContextHandler.go
+++ b/backend/pkg/handlers/videoContextHandler.go
@@ -143,17 +143,16 @@ func TruncateTranscript(transcript []string, maxTokens int) []string {
 	}
 	totalTokens:=0
 	var resultTranscript []string
+	// Encode each transcript element one by one(123:hello, my name is) into tokens and see if adding it to total tokens would exceed maxTokens
 	for _,entry := range transcript {
 		tokenIds, _, err := enc.Encode(entry)
 		if err != nil {
 			log.Printf("Error encoding entry: %v", err)
 			continue 
-		}
-		
+		}		
 		if totalTokens + len(tokenIds) > maxTokens {
 			break
 		}
-		
 		resultTranscript = append(resultTranscript, entry)
 		totalTokens += len(tokenIds)
 	}


### PR DESCRIPTION
**Problem**

- Users get an error when trying to use learning mode for a video longer than around 4 hours

**Solution**
- Used a tokenizer library to encode each transcript entry one by one and add it to a new slice only if the token limit hasn't been exceeded yet. This cuts off entries cleanly and makes sure we're not cutting off the middle of a time stamp or something.
- Logs  the timestamp that the transcript was cut off at in seconds, and hours/minutes.
- Saves the truncated transcript into redis

https://github.com/user-attachments/assets/b4992172-549f-4d8b-947f-95e64d8a40fe

