### PR TITLE
fix passing of userId prop to QuizFetcher so it is properly sent to b…

### DIFF
--- a/extention/components/container2.js
+++ b/extention/components/container2.js
@@ -6,7 +6,7 @@ import React from 'react';
 import { BASE_URL } from '../js/env.js';
 
 
-export function createContainer2(parentElement) {
+export function createContainer2(parentElement, userId) {
 
   const featuresPanel = document.createElement('div');
   featuresPanel.id = 'features-panel';
@@ -162,7 +162,7 @@ export function createContainer2(parentElement) {
           const quizRoot = createRoot(quizHolder);
 
 
-          quizRoot.render(<QuizFetcher key={Date.now()} />); // Re-render the QuizFetcher component
+          quizRoot.render(<QuizFetcher key={Date.now()} userId = {userId}/>); // Re-render the QuizFetcher component
           console.log('Quiz generated');
 
           return;


### PR DESCRIPTION
### Problem
- `UserID` was never properly passed to the `QuizFetcher`.
- As a result, quizzes were saved in Redis with an empty `userID ("")` instead of the actual user ID.
<img width="1412" height="37" alt="image" src="https://github.com/user-attachments/assets/8a2d06b5-352e-4f3b-be99-b4a137dca608" />

### Solution

- This fix ensures UserID is correctly passed through QuizFetcher to the main backend -> Quiz Service.
- Prevents quizzes from being saved into redis / searched up into redis with an invalid or empty userID.
<img width="1432" height="49" alt="image" src="https://github.com/user-attachments/assets/ffbe3300-493e-43d8-89ef-588cf958cf4d" />
